### PR TITLE
Refactor scene_conf icon retrieval to use get() method

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -95,7 +95,7 @@ class Hub:
         return {
             "name": scene_conf["name"],
             "id": scene_conf["id"],
-            "icon": scene_conf["icon"] if "icon" in scene_conf else None,
+            "icon": scene_conf.get("icon", None),
             "entity_id": entity_id,
             "entities": entities,
         }


### PR DESCRIPTION
This pull request refactors the scene_conf icon retrieval to use the get() method instead of checking if the "icon" key exists in the scene_conf dictionary. This improves code readability and reduces the chance of a KeyError.