### PR TITLE
Add area_id to scene configuration

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -5,6 +5,7 @@ import logging
 import yaml
 import os
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import area_id
 
 from .const import ATTRIBUTES_TO_CHECK
 
@@ -27,7 +28,6 @@ def get_entity_id_from_id(hass: HomeAssistant, id: str) -> str:
         if state.attributes["id"] == id:
             return entity_id
     return None
-
 
 def get_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
     """Get scene id from entity_id."""
@@ -166,6 +166,7 @@ class Hub:
             "id": scene_conf["id"],
             "icon": scene_conf.get("icon", None),
             "entity_id": entity_id,
+            "area": area_id(self.hass, entity_id),
             "learn": scene_conf.get("learn", False),
             "entities": entities,
         }
@@ -177,6 +178,7 @@ class Hub:
             "id": get_id_from_entity_id(self.hass, entity_id),
             "icon": None,
             "entity_id": entity_id,
+            "area": area_id(self.hass, entity_id),
             "learn": True,
             "entities": entities,
         }
@@ -194,6 +196,7 @@ class Scene:
         self.name = scene_conf["name"]
         self._entity_id = scene_conf["entity_id"]
         self._id = scene_conf["id"]
+        self.area_id = scene_conf["area"]
         self.learn = scene_conf["learn"]
         self.entities = scene_conf["entities"]
         self.icon = scene_conf["icon"]

--- a/custom_components/stateful_scenes/number.py
+++ b/custom_components/stateful_scenes/number.py
@@ -79,6 +79,7 @@ class TransitionNumber(RestoreNumber):
             identifiers={(self._scene.id,)},
             name=self._scene.name,
             manufacturer=DEVICE_INFO_MANUFACTURER,
+            suggested_area=self._scene.area_id,
         )
 
     def set_native_value(self, value: float) -> None:

--- a/custom_components/stateful_scenes/switch.py
+++ b/custom_components/stateful_scenes/switch.py
@@ -122,6 +122,7 @@ class StatefulSceneSwitch(SwitchEntity):
         return DeviceInfo(
             identifiers={(self._scene.id,)},
             name=self._scene.name,
+            suggested_area=self._scene.area_id,
             manufacturer=DEVICE_INFO_MANUFACTURER,
         )
 
@@ -188,6 +189,7 @@ class RestoreOnDeactivate(SwitchEntity):
             identifiers={(self._scene.id,)},
             name=self._scene.name,
             manufacturer=DEVICE_INFO_MANUFACTURER,
+            suggested_area=self._scene.area_id,
         )
 
     @property


### PR DESCRIPTION
This pull request adds the `area_id` attribute to the scene configuration, allowing scenes to be associated with specific areas in Home Assistant.