### PR TITLE
Fix attribute access in StatefulScenes.py

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -25,14 +25,14 @@ def get_entity_id_from_id(hass: HomeAssistant, id: str) -> str:
     entity_ids = hass.states.async_entity_ids("scene")
     for entity_id in entity_ids:
         state = hass.states.get(entity_id)
-        if state.attributes["id"] == id:
+        if state.attributes.get("id", None) == id:
             return entity_id
     return None
 
 def get_id_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:
     """Get scene id from entity_id."""
     state = hass.states.get(entity_id)
-    return state.attributes["id"]
+    return state.attributes.get("id", entity_id)
 
 
 def get_name_from_entity_id(hass: HomeAssistant, entity_id: str) -> str:


### PR DESCRIPTION
This pull request fixes the attribute access in the StatefulScenes.py file. Previously, the code was accessing the "id" attribute directly, which could result in an error if the attribute was not present. This PR updates the code to use the "get" method to safely access the attribute, providing a default value of None if the attribute is not found.