### PR TITLE
refactor: scene update callbacks

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -5,7 +5,7 @@ import logging
 
 import yaml
 import os
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, Event, EventStateChangedData
 from homeassistant.helpers.template import area_id
 from .helpers import (
     get_name_from_entity_id,
@@ -308,8 +308,12 @@ class Scene:
             self.callback()
             self.callback = None
 
-    async def update_callback(self, entity_id, old_state, new_state):
+    async def update_callback(self, event: Event[EventStateChangedData]):
         """Update the scene when a tracked entity changes state."""
+        entity_id = event.data.get("entity_id")
+        new_state = event.data.get("new_state")
+        old_state = event.data.get("old_state")
+
         self.store_entity_state(entity_id, old_state)
         if self.is_interesting_update(old_state, new_state):
             await asyncio.sleep(self.debounce_time)

--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -42,10 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         discovery_manager = DiscoveryManager(hass, entry)
         await discovery_manager.start_discovery()
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/stateful_scenes/switch.py
+++ b/custom_components/stateful_scenes/switch.py
@@ -13,7 +13,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import StatefulScenes
@@ -156,7 +156,7 @@ class StatefulSceneSwitch(SwitchEntity):
     def register_callback(self) -> None:
         """Register callback to update hass when state changes."""
         self._scene.register_callback(
-            state_change_func=async_track_state_change,
+            state_change_func=async_track_state_change_event,
             schedule_update_func=self.schedule_update_ha_state,
         )
 


### PR DESCRIPTION
This pull request refactors the scene update callbacks to use the new event data format following the deprecation of `async_track_state_change`. The `update_callback` method now accepts an event object instead of individual parameters. Additionally, the `async_setup_entry` function has been updated to use `async_forward_entry_setups` instead of individually forwarding each platform.