### PR TITLE
fix: Add callback functions to scene registration

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -219,6 +219,7 @@ class Scene:
         self._debounce_time: float = 0
 
         self.callback = None
+        self.callback_funcs = {}
         self.schedule_update = None
         self.states = {entity_id: False for entity_id in self.entities}
         self.restore_states = {entity_id: None for entity_id in self.entities}
@@ -295,8 +296,12 @@ class Scene:
         """Set the restore on deactivate flag."""
         self._restore_on_deactivate = restore_on_deactivate
 
-    def register_callback(self, state_change_func, schedule_update_func):
+    def register_callback(self):
         """Register callback."""
+        schedule_update_func = self.callback_funcs.get("schedule_update_func", None)
+        state_change_func = self.callback_funcs.get("state_change_func", None)
+        if schedule_update_func is None or state_change_func is None:
+            raise ValueError("No callback functions provided for scene.")
         self.schedule_update = schedule_update_func
         self.callback = state_change_func(
             self.hass, self.entities.keys(), self.update_callback

--- a/custom_components/stateful_scenes/switch.py
+++ b/custom_components/stateful_scenes/switch.py
@@ -105,6 +105,10 @@ class StatefulSceneSwitch(SwitchEntity):
         self._icon = scene.icon
         self._attr_unique_id = f"stateful_{scene.id}"
 
+        self._scene.callback_funcs = {
+            "state_change_func":async_track_state_change_event,
+            "schedule_update_func":self.schedule_update_ha_state
+            }
         self.register_callback()
 
     @property
@@ -156,10 +160,7 @@ class StatefulSceneSwitch(SwitchEntity):
 
     def register_callback(self) -> None:
         """Register callback to update hass when state changes."""
-        self._scene.register_callback(
-            state_change_func=async_track_state_change_event,
-            schedule_update_func=self.schedule_update_ha_state,
-        )
+        self._scene.register_callback()
 
     def unregister_callback(self) -> None:
         """Unregister callback."""


### PR DESCRIPTION
This pull request adds callback functions to the scene registration process. Previously, the callback functions were not being properly set, leading to errors when attempting to update a scene (see #97). With this change, the callback functions are properly set, ensuring that the scene registration process functions correctly.