### PR TITLE
fix: display switch as a toggle rather than flashes

### DIFF
--- a/custom_components/stateful_scenes/switch.py
+++ b/custom_components/stateful_scenes/switch.py
@@ -92,7 +92,7 @@ async def async_setup_entry(
 class StatefulSceneSwitch(SwitchEntity):
     """Representation of an Awesome Light."""
 
-    _attr_assumed_state = True
+    _attr_assumed_state = False
     _attr_has_entity_name = True
     _attr_name = "Stateful Scene"
     _attr_should_poll = False


### PR DESCRIPTION
This pull request fixes the issue where the display switch was flashing instead of being displayed as a toggle. The `_attr_assumed_state` attribute has been changed from `True` to `False` in the `StatefulSceneSwitch` class.