### PR TITLE
fix(scene): do not restore if already off

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -259,6 +259,9 @@ class Scene:
 
     def turn_off(self):
         """Turn off all entities in the scene."""
+        if not self._is_on:  # already off
+            return
+
         if self.restore_on_deactivate:
             self.restore()
         else:
@@ -267,6 +270,7 @@ class Scene:
                 service="turn_off",
                 target={"entity_id": list(self.entities.keys())},
             )
+
         self._is_on = False
 
     @property


### PR DESCRIPTION
This pull request fixes an issue where the scene restoration was triggered even when the scene was already turned off. The commit "fix(scene): do not restore if already off" ensures that the restoration is skipped if the scene is already off.