### PR TITLE
fix: correct documentation link

### DIFF
--- a/custom_components/stateful_scenes/manifest.json
+++ b/custom_components/stateful_scenes/manifest.json
@@ -5,7 +5,7 @@
     "@hugobloem"
   ],
   "config_flow": true,
-  "documentation": "https://raw.githubusercontent.com/hugobloem/stateful_scenes/main/README.md",
+  "documentation": "https://github.com/hugobloem/stateful_scenes",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/hugobloem/stateful_scenes/issues",
   "version": "1.3.2"


### PR DESCRIPTION
This pull request includes a small change to the `custom_components/stateful_scenes/manifest.json` file. The change updates the documentation URL to point directly to the GitHub repository instead of the raw README file.

* [`custom_components/stateful_scenes/manifest.json`](diffhunk://#diff-dd23a4a92450f8aa8d142e0c68e0bcbb935fbc9931c1919c887d32315fb05fd5L8-R8): Updated the documentation URL to "https://github.com/hugobloem/stateful_scenes"