### PR TITLE
ci: use uv in lint.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,4 +22,4 @@ jobs:
             version: "latest"
 
         - name: "Run"
-          run: uv run ruff check .
+          run: uv tool run ruff check .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,13 +17,12 @@ jobs:
           uses: "actions/checkout@v4"
 
         - name: "Set up Python"
-          uses: actions/setup-python@v5
+          uses: astral-sh/setup-uv@v3
           with:
-            python-version: "3.11"
-            cache: "pip"
+            version: "latest"
 
         - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+          run: python3 -m uv pip install -r requirements.txt
 
         - name: "Run"
           run: python3 -m ruff check .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,8 +21,5 @@ jobs:
           with:
             version: "latest"
 
-        - name: "Install requirements"
-          run: python3 -m uv pip install -r requirements.txt
-
         - name: "Run"
-          run: python3 -m ruff check .
+          run: uv run ruff check .


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/lint.yaml` file to update the setup process for the linting job. The most important changes involve switching from using Python to using UV, a different setup tool.

Updates to the linting job setup:

* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL20-R25): Changed from using `actions/setup-python@v5` to `astral-sh/setup-uv@v3` for setting up the environment.
* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL20-R25): Updated the version parameter from specifying `python-version: "3.11"` to `version: "latest"`.
* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL20-R25): Modified the command for installing requirements from `python3 -m pip install -r requirements.txt` to `python3 -m uv pip install -r requirements.txt`.