### PR TITLE
fix: update Hub signature in config flow - fixes #147

### DIFF
--- a/custom_components/stateful_scenes/config_flow.py
+++ b/custom_components/stateful_scenes/config_flow.py
@@ -7,6 +7,7 @@ import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import selector
+from . import load_scenes_file
 
 from .const import (
     CONF_DEBOUNCE_TIME,
@@ -79,9 +80,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                self.hub = Hub(
+                scene_confs = await load_scenes_file(user_input[CONF_SCENE_PATH])
+                _ = Hub(
                     hass=self.hass,
-                    scene_path=user_input[CONF_SCENE_PATH],
+                    scene_confs=scene_confs,
                     number_tolerance=user_input[CONF_NUMBER_TOLERANCE],
                 )
             except StatefulScenesYamlInvalid as err:


### PR DESCRIPTION
This pull request includes updates to the `custom_components/stateful_scenes/config_flow.py` file to enhance the handling of scene configurations. The main changes involve loading scene configurations from a file and updating the `Hub` initialization process.

Enhancements to scene configuration handling:

* [`custom_components/stateful_scenes/config_flow.py`](diffhunk://#diff-be68aff14d16d60ad12c055195a9ffee6fe702280d829e9398ce15a766c77f4cR10): Added an import statement for the `load_scenes_file` function to facilitate loading scene configurations from a file.
* `async def async_step_configure_internal_scenes(` in `custom_components/stateful_scenes/config_flow.py`: Modified the initialization of the `Hub` by loading scene configurations using the `load_scenes_file` function and passing the configurations to the `Hub` constructor instead of the scene path.