### PR TITLE
fix: If the scene 'on' state includes entities that are off don't check additional attributes

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -253,7 +253,7 @@ class Scene:
         return False
 
     def check_state(self, entity_id, new_state):
-        """Check the state of the scene."""
+        """Check if entity's current state matches the scene's defined state."""
         if new_state is None:
             _LOGGER.warning(f"Entity not found: {entity_id}")
             return False
@@ -273,6 +273,11 @@ class Scene:
             return False
 
         # Check attributes
+        # If both desired and current states are "off", consider it a match regardless of attributes
+        if new_state.state == "off" and self.entities[entity_id]["state"] == "off":
+            return True
+
+        # Only check attributes if entity isn't "off"
         if new_state.domain in ATTRIBUTES_TO_CHECK:
             entity_attrs = new_state.attributes
             for attribute in ATTRIBUTES_TO_CHECK.get(new_state.domain):


### PR DESCRIPTION
The current behavior is to compare all attributes regardless if the device is off which fails a match for devices that are off when individual attributes change.  For example  a scene that, by definition, turns off all of its devices will not be considered on/active if any individual attribute is different than the defined scene entity state.

If a scene includes entities that have a defined off state those entities should be considered off regardless of their other attributes in the off state.  For example a thermostat temperature may be changed from the original scene definition but the thermostat is still off, etc.  A light's color may be blue instead of red but the light is still off.  It is common for attributes like brightness to vary when a device is off but off is the overriding characteristic unlike when the device is on.

This issue addresses issue #106 

