### PR TITLE
fix: Modify the integration to fully use HA async paradigm.

### DIFF
--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -28,6 +28,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 
+
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
@@ -54,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if is_hub and entry.data.get(CONF_ENABLE_DISCOVERY, False):
         discovery_manager = DiscoveryManager(hass, entry)
-        await discovery_manager.start_discovery()
+        await discovery_manager.async_start_discovery()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/stateful_scenes/discovery.py
+++ b/custom_components/stateful_scenes/discovery.py
@@ -34,7 +34,7 @@ class DiscoveryManager:
         self.hass = hass
         self.ha_config = ha_config
 
-    async def start_discovery(self) -> None:
+    async def async_start_discovery(self) -> None:
         """Start the discovery procedure."""
         _LOGGER.debug("Start auto discovering devices")
         entity_registry = er.async_get(self.hass)

--- a/custom_components/stateful_scenes/number.py
+++ b/custom_components/stateful_scenes/number.py
@@ -98,7 +98,7 @@ class TransitionNumber(RestoreNumber):
             suggested_area=self._scene.area_id,
         )
 
-    def set_native_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._scene.set_transition_time(value)
 
@@ -159,7 +159,7 @@ class DebounceTime(RestoreNumber):
             manufacturer=DEVICE_INFO_MANUFACTURER,
         )
 
-    def set_native_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._scene.set_debounce_time(value)
 
@@ -220,7 +220,7 @@ class Tolerance(RestoreNumber):
             manufacturer=DEVICE_INFO_MANUFACTURER,
         )
 
-    def set_native_value(self, value: int) -> None:
+    async def async_set_native_value(self, value: int) -> None:
         """Update the current value."""
         self._scene.set_number_tolerance(value)
 

--- a/custom_components/stateful_scenes/select.py
+++ b/custom_components/stateful_scenes/select.py
@@ -73,7 +73,9 @@ class StatefulSceneOffSelect(SelectEntity, RestoreEntity):
         self._cache: dict[str, bool | DeviceInfo] = {}
         self._attr_entity_category = EntityCategory.CONFIG
         self._restore_on_deactivate_state: str | None = None
-        self._off_scene_entity_id: str | None = None  # Variable to store the off scene entity ID
+        self._off_scene_entity_id: str | None = (
+            None  # Variable to store the off scene entity ID
+        )
 
     def _get_available_off_scenes(self) -> list[tuple[str, str]]:
         """Get list of available scenes with friendly names."""
@@ -168,9 +170,16 @@ class StatefulSceneOffSelect(SelectEntity, RestoreEntity):
                 self._off_scene_entity_id = stored_entity_id
                 state = self.hass.states.get(stored_entity_id)
                 if state:
-                    self._attr_current_option = state.attributes.get("friendly_name", stored_entity_id)
+                    self._attr_current_option = state.attributes.get(
+                        "friendly_name", stored_entity_id
+                    )
             # Fall back to friendly name  if no stored entity_id for backward compatibility to 1.60
-            elif last_state.state not in [None, "unavailable", "unknown", DEFAULT_OFF_SCENE_ENTITY_ID]:
+            elif last_state.state not in [
+                None,
+                "unavailable",
+                "unknown",
+                DEFAULT_OFF_SCENE_ENTITY_ID,
+            ]:
                 restored_state = last_state.state
                 if not restored_state.startswith("scene."):
                     # Map friendly name to entity_id
@@ -210,7 +219,7 @@ class StatefulSceneOffSelect(SelectEntity, RestoreEntity):
             suggested_area=self._scene.area_id,
         )
 
-    def select_option(self, option: str) -> None:
+    async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
         self._attr_current_option = option
 
@@ -220,8 +229,8 @@ class StatefulSceneOffSelect(SelectEntity, RestoreEntity):
             # Map friendly name to entity_id
             self._off_scene_entity_id = self._entity_id_map.get(option)
 
-        self._scene.set_off_scene(self._off_scene_entity_id)
-        self.schedule_update_ha_state()
+        await self._scene.async_set_off_scene(self._off_scene_entity_id)
+        self.async_schedule_update_ha_state()
 
         _LOGGER.debug(
             "Selected off scene for %s: %s (entity_id: %s)",


### PR DESCRIPTION
Eliminate unnecessary calls to asyncio.run_coroutine_threadsafe due to sync methods calling async routines for eval with the eval timer.  The entire integration is now async.

The switch now relies on the Scene to fully initialize in the scene's init solving a race condition where the switch was trying to get the scene to update its state / eval while it may not be initialized.  The switch now relies solely on the scene is_on so it is always in sync with the scene.

Addresses issue #170 and #174.  Apologies for the sweeping change but async is really necessary given the interactions with switch, debounce.  