### PR TITLE
chore: Update Python interpreter path and streamline setup script

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -22,7 +22,7 @@
             "settings": {
                 "files.eol": "\n",
                 "editor.tabSize": 4,
-                "python.pythonPath": "/usr/bin/python3",
+                "python.defaultInterpreterPath": ".venv/bin/python",
                 "python.analysis.autoSearchPaths": false,
                 "python.linting.pylintEnabled": true,
                 "python.linting.enabled": true,

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,8 +2,10 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-python3 -m pip install uv
+# cd "$(dirname "$0")/.."
 
-python3 -m uv pip install --requirement requirements.txt
+uv venv
+source .venv/bin/activate
+uv pip install --requirement requirements.txt


### PR DESCRIPTION
Change the Python interpreter path to use a virtual environment and simplify the setup process by incorporating a direct installation script.