### PR TITLE
refactor: simplify state initialization using dict.fromkeys

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -132,8 +132,8 @@ class Scene:
         self.callback = None
         self.callback_funcs = {}
         self.schedule_update = None
-        self.states = {entity_id: False for entity_id in self.entities}
-        self.restore_states = {entity_id: None for entity_id in self.entities}
+        self.states = dict.fromkeys(self.entities, False)
+        self.restore_states = dict.fromkeys(self.entities)
 
         if self.learn:
             self.learned = False


### PR DESCRIPTION
Simplify the initialization of states and restore states using `dict.fromkeys` for improved readability and efficiency.