### PR TITLE
fix: debounce not applied to storage of previous states

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -348,13 +348,13 @@ class Scene:
             new_state.state if new_state else None,
         )
 
-        # Store the old state
-        await self.async_store_entity_state(entity_id, old_state)
-
         # Check if this update is interesting
         if self.is_interesting_update(old_state, new_state):
             if not self._scene_evaluation_timer.is_active():
                 await self.async_evaluate_scene_state()
+
+                # Store the old state
+                await self.async_store_entity_state(entity_id, old_state)
 
     async def async_evaluate_scene_state(self):
         """Evaluate scene state immediately."""


### PR DESCRIPTION
This pull request modifies the `async_update_callback` method in the `StatefulScenes.py` file to adjust the timing of when the old state is stored. The change ensures that the old state is only stored if the update is deemed interesting.

Key change in logic:

* Moved the call to `async_store_entity_state` so that the old state is stored only after confirming the update is interesting by `is_interesting_update`. This prevents unnecessary state storage for uninteresting updates.

BEGIN_COMMIT_OVERRIDE
fix: debounce not applied to storage of previous states
END_COMMIT_OVERRIDE