### PR TITLE
fix: YAML boolean state parsing issue

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -710,7 +710,11 @@ class Hub:
         entities = {}
         for entity_id, scene_attributes in scene_conf["entities"].items():
             domain = entity_id.split(".")[0]
-            attributes = {"state": scene_attributes["state"]}
+            # Convert boolean states to strings (YAML parses 'on'/'off' as bool)
+            state = scene_attributes["state"]
+            if isinstance(state, bool):
+                state = "on" if state else "off"
+            attributes = {"state": state}
 
             if domain in ATTRIBUTES_TO_CHECK:
                 for attribute, value in scene_attributes.items():


### PR DESCRIPTION
YAML's FullLoader parses unquoted 'on' and 'off' as boolean values (True/False) instead of strings. This caused scene state matching to fail because Home Assistant entity states are strings ("on"/"off"), not booleans.

The fix converts boolean state values to their string equivalents after loading from YAML, ensuring compatibility with both quoted and unquoted state values in scenes.yaml files.

Fixes scene evaluation when using unquoted state values like:
```
  state: on  # parsed as True, now converted to "on"
  state: off # parsed as False, now converted to "off"
```