### PR TITLE
fix: import issue 2025.12

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -33,6 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def area_name(hass: HomeAssistant, entity_id: str) -> str:
+    """Get area name from entity_id."""
     area_reg = ar.async_get(hass)
     if area := area_reg.async_get_area(resolve_area_id(hass, entity_id)):
         return area.name
@@ -772,5 +773,6 @@ class Hub:
         return next(
             (scene for scene in self.scenes if scene.entity_id == scene_id), None
         )
+
 
 


### PR DESCRIPTION
There is an import issue when this integration is used with 2025.12.0b0.

They removed (exactly moved) the area_id and area_name methods from the homeassistant.helpers.template in https://github.com/home-assistant/core/commit/e5b2d44e8ebe90390d29b4171598673e6344d196.

This PR fixes it by using the resolve_area_id (which is almost identical to the old area_id) and copying part of the area_name logic to a local function.