### PR TITLE
feat: add entry removal cleanup and reconfigure flow

### DIFF
--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -78,10 +78,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Handle removal of an entry."""
+    """Handle unloading of an entry."""
     if unloaded := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle removal of an entry."""
+    from homeassistant.helpers import entity_registry, device_registry
+
+    er = entity_registry.async_get(hass)
+    dr = device_registry.async_get(hass)
+
+    # Remove all entities associated with this config entry
+    entities_to_remove = [
+        entity_id
+        for entity_id, entity in er.entities.items()
+        if entity.config_entry_id == entry.entry_id
+    ]
+    for entity_id in entities_to_remove:
+        er.async_remove(entity_id)
+
+    # Remove all devices associated with this config entry
+    devices_to_remove = [
+        device_id
+        for device_id, device in dr.devices.items()
+        if entry.entry_id in device.config_entries
+    ]
+    for device_id in devices_to_remove:
+        dr.async_remove_device(device_id)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/stateful_scenes/config_flow.py
+++ b/custom_components/stateful_scenes/config_flow.py
@@ -52,6 +52,72 @@ from .StatefulScenes import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _scene_settings_schema(defaults: dict) -> dict:
+    """Build the common scene settings schema fields."""
+    return {
+        vol.Optional(
+            CONF_NUMBER_TOLERANCE,
+            default=defaults.get(CONF_NUMBER_TOLERANCE, DEFAULT_NUMBER_TOLERANCE),
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=TOLERANCE_MIN, max=TOLERANCE_MAX, step=TOLERANCE_STEP
+            )
+        ),
+        vol.Optional(
+            CONF_RESTORE_STATES_ON_DEACTIVATE,
+            default=defaults.get(
+                CONF_RESTORE_STATES_ON_DEACTIVATE,
+                DEFAULT_RESTORE_STATES_ON_DEACTIVATE,
+            ),
+        ): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_TRANSITION_TIME,
+            default=defaults.get(CONF_TRANSITION_TIME, DEFAULT_TRANSITION_TIME),
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=TRANSITION_MIN, max=TRANSITION_MAX, step=TRANSITION_STEP
+            )
+        ),
+        vol.Optional(
+            CONF_DEBOUNCE_TIME,
+            default=defaults.get(CONF_DEBOUNCE_TIME, DEFAULT_DEBOUNCE_TIME),
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=DEBOUNCE_MIN, max=DEBOUNCE_MAX, step=DEBOUNCE_STEP
+            )
+        ),
+        vol.Optional(
+            CONF_IGNORE_UNAVAILABLE,
+            default=defaults.get(CONF_IGNORE_UNAVAILABLE, DEFAULT_IGNORE_UNAVAILABLE),
+        ): selector.BooleanSelector(),
+    }
+
+
+def _hub_schema(defaults: dict) -> vol.Schema:
+    """Build the full hub configuration schema."""
+    scene_path = defaults.get(CONF_SCENE_PATH, DEFAULT_SCENE_PATH)
+    fields = {
+        vol.Optional(
+            CONF_SCENE_PATH,
+            default=scene_path,
+            description={"suggested_value": scene_path},
+        ): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        ),
+        **_scene_settings_schema(defaults),
+        vol.Optional(
+            CONF_ENABLE_DISCOVERY,
+            default=defaults.get(CONF_ENABLE_DISCOVERY, DEFAULT_ENABLE_DISCOVERY),
+        ): selector.BooleanSelector(),
+    }
+    return vol.Schema(fields)
+
+
+def _external_schema(defaults: dict) -> vol.Schema:
+    """Build the external scene settings schema."""
+    return vol.Schema(_scene_settings_schema(defaults))
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Blueprint."""
 
@@ -97,6 +163,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return (DEFAULT_SCENE_PATH, warning)
 
+    async def _async_validate_hub_input(self, user_input: dict) -> dict[str, str]:
+        """Validate hub user input. Returns errors dict (empty on success)."""
+        errors = {}
+        try:
+            scene_confs = await load_scenes_file(self.hass, user_input[CONF_SCENE_PATH])
+            _ = Hub(
+                hass=self.hass,
+                scene_confs=scene_confs,
+                number_tolerance=user_input[CONF_NUMBER_TOLERANCE],
+            )
+        except StatefulScenesYamlInvalid as err:
+            _LOGGER.warning(err)
+            errors["base"] = "invalid_yaml"
+        except StatefulScenesYamlNotFound as err:
+            _LOGGER.warning(err)
+            errors["base"] = "yaml_not_found"
+        except Exception as err:
+            _LOGGER.warning(err)
+            errors["base"] = "unknown"
+        return errors
+
     async def async_step_user(self, user_input: dict | None = None) -> dict:
         """Handle a flow initialized by the user."""
         return self.async_show_menu(
@@ -115,25 +202,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            try:
-                scene_confs = await load_scenes_file(
-                    self.hass, user_input[CONF_SCENE_PATH]
-                )
-                _ = Hub(
-                    hass=self.hass,
-                    scene_confs=scene_confs,
-                    number_tolerance=user_input[CONF_NUMBER_TOLERANCE],
-                )
-            except StatefulScenesYamlInvalid as err:
-                _LOGGER.warning(err)
-                errors["base"] = "invalid_yaml"
-            except StatefulScenesYamlNotFound as err:
-                _LOGGER.warning(err)
-                errors["base"] = "yaml_not_found"
-            except Exception as err:
-                _LOGGER.warning(err)
-                errors["base"] = "unknown"
-            else:
+            errors = await self._async_validate_hub_input(user_input)
+            if not errors:
                 self.configuration.update(user_input)
                 self.configuration["hub"] = True
                 return self.async_create_entry(
@@ -153,50 +223,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="configure_internal_scenes",
             last_step=True,
             description_placeholders=description_placeholders if path_warning else None,
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_SCENE_PATH,
-                        default=detected_path,
-                        description={"suggested_value": detected_path},
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT,
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_NUMBER_TOLERANCE, default=DEFAULT_NUMBER_TOLERANCE
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=TOLERANCE_MIN, max=TOLERANCE_MAX, step=TOLERANCE_STEP
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_RESTORE_STATES_ON_DEACTIVATE,
-                        default=DEFAULT_RESTORE_STATES_ON_DEACTIVATE,
-                    ): selector.BooleanSelector(),
-                    vol.Optional(
-                        CONF_TRANSITION_TIME, default=DEFAULT_TRANSITION_TIME
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=TRANSITION_MIN, max=TRANSITION_MAX, step=TRANSITION_STEP
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_DEBOUNCE_TIME, default=DEFAULT_DEBOUNCE_TIME
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=DEBOUNCE_MIN, max=DEBOUNCE_MAX, step=DEBOUNCE_STEP
-                        )
-                    ),
-                    vol.Optional(
-                        CONF_IGNORE_UNAVAILABLE, default=DEFAULT_IGNORE_UNAVAILABLE
-                    ): selector.BooleanSelector(),
-                    vol.Optional(
-                        CONF_ENABLE_DISCOVERY, default=DEFAULT_ENABLE_DISCOVERY
-                    ): selector.BooleanSelector(),
-                }
-            ),
+            data_schema=_hub_schema({CONF_SCENE_PATH: detected_path}),
             errors=errors,
         )
 
@@ -261,7 +288,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="select_external_scenes",
             data_schema=vol.Schema(
                 {
-                    # Define the fields for your second flow here
                     vol.Optional(CONF_SCENE_ENTITY_ID): selector.EntitySelector(
                         {
                             "filter": {"domain": "scene"},
@@ -291,7 +317,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="configure_external_scene_entities",
             data_schema=vol.Schema(
                 {
-                    # Define the fields for your second flow here
                     vol.Optional(
                         CONF_SCENE_ENTITIES, default=[]
                     ): selector.EntitySelector(
@@ -347,7 +372,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="learn_external_scene",
             data_schema=vol.Schema(
                 {
-                    # Define the fields for your second flow here
                     vol.Optional(
                         CONF_EXTERNAL_SCENE_ACTIVE,
                         default=DEFAULT_EXTERNAL_SCENE_ACTIVE,
@@ -359,4 +383,113 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 or "Unknown Entity",
             },
             errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reconfiguration of an existing entry."""
+        entry = self._get_reconfigure_entry()
+        is_hub = entry.data.get("hub", CONF_SCENE_PATH in entry.data)
+
+        if is_hub:
+            return await self.async_step_reconfigure_hub(user_input)
+        return await self.async_step_reconfigure_external(user_input)
+
+    async def async_step_reconfigure_hub(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reconfiguration of a hub entry."""
+        entry = self._get_reconfigure_entry()
+        errors = {}
+
+        if user_input is not None:
+            errors = await self._async_validate_hub_input(user_input)
+            if not errors:
+                user_input["hub"] = True
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure_hub",
+            data_schema=_hub_schema(dict(entry.data)),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_external(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reconfiguration of an external scene entry."""
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            new_entities = user_input.pop(CONF_SCENE_ENTITIES, None)
+            current_entities = list(entry.data.get("entities", {}).keys())
+
+            # If entities changed, store settings and go to re-learn step
+            if new_entities is not None and sorted(new_entities) != sorted(
+                current_entities
+            ):
+                self.configuration = dict(entry.data)
+                self.configuration.update(user_input)
+                self.configuration["_new_entities"] = new_entities
+                return await self.async_step_reconfigure_external_learn()
+
+            # Entities unchanged, just update settings
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates=user_input,
+            )
+
+        current_entities = list(entry.data.get("entities", {}).keys())
+        schema_fields = _scene_settings_schema(dict(entry.data))
+        schema_fields[vol.Optional(CONF_SCENE_ENTITIES, default=current_entities)] = (
+            selector.EntitySelector({"multiple": True})
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure_external",
+            data_schema=vol.Schema(schema_fields),
+        )
+
+    async def async_step_reconfigure_external_learn(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Re-learn scene states after entity changes."""
+        entry = self._get_reconfigure_entry()
+        entity_id = self.configuration.get("entity_id")
+        new_entities = self.configuration.get("_new_entities")
+
+        await self.hass.services.async_call(
+            domain="scene",
+            service="turn_on",
+            target={"entity_id": entity_id},
+            service_data={"transition": 0},
+        )
+
+        if user_input is not None and user_input.get(CONF_EXTERNAL_SCENE_ACTIVE, False):
+            learned_states = Scene.learn_scene_states(self.hass, new_entities)
+            self.configuration.pop("_new_entities", None)
+            self.configuration["entities"] = learned_states
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates=self.configuration,
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_external_learn",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_EXTERNAL_SCENE_ACTIVE,
+                        default=DEFAULT_EXTERNAL_SCENE_ACTIVE,
+                    ): selector.BooleanSelector(),
+                }
+            ),
+            description_placeholders={
+                "entity_name": get_name_from_entity_id(self.hass, entity_id)
+                or "Unknown Entity",
+            },
         )

--- a/custom_components/stateful_scenes/translations/en.json
+++ b/custom_components/stateful_scenes/translations/en.json
@@ -40,6 +40,35 @@
                 "data": {
                     "external_scene_active": "Activated?"
                 }
+            },
+            "reconfigure_hub": {
+                "description": "Reconfigure your Stateful Scenes settings.",
+                "data": {
+                    "scene_path": "Scene path",
+                    "number_tolerance": "Rounding tolerance",
+                    "restore_states_on_deactivate": "Restore states on deactivation",
+                    "transition_time": "Transition time",
+                    "debounce_time": "Debounce time",
+                    "ignore_unavailable": "Ignore entities in unavailable state",
+                    "enable_discovery": "Enable discovery"
+                }
+            },
+            "reconfigure_external": {
+                "description": "Reconfigure your external scene settings and entities.",
+                "data": {
+                    "number_tolerance": "Rounding tolerance",
+                    "restore_states_on_deactivate": "Restore states on deactivation",
+                    "transition_time": "Transition time",
+                    "debounce_time": "Debounce time",
+                    "ignore_unavailable": "Ignore entities in unavailable state",
+                    "scene_entities": "Scene entities"
+                }
+            },
+            "reconfigure_external_learn": {
+                "description": "The scene has been activated. Confirm that {entity_name} is in the desired state.",
+                "data": {
+                    "external_scene_active": "Activated?"
+                }
             }
         },
         "error": {
@@ -48,6 +77,9 @@
             "unknown": "Unknown error occurred",
             "no_entity_id": "No entity ID found",
             "hub_not_found": "Main entry not found, configure Stateful Scenes first"
+        },
+        "abort": {
+            "reconfigure_successful": "Configuration updated successfully"
         }
     }
 }

--- a/custom_components/stateful_scenes/translations/nl.json
+++ b/custom_components/stateful_scenes/translations/nl.json
@@ -39,6 +39,35 @@
                 "data": {
                     "external_scene_active": "Geactiveerd?"
                 }
+            },
+            "reconfigure_hub": {
+                "description": "Herconfigureer uw Stateful Scenes instellingen.",
+                "data": {
+                    "scene_path": "Scènebestand pad",
+                    "number_tolerance": "Afrondingstolerantie",
+                    "restore_states_on_deactivate": "Status herstellen bij deactivering",
+                    "transition_time": "Transitie tijd",
+                    "debounce_time": "Debouncetijd",
+                    "ignore_unavailable": "Negeer entiteiten in niet-beschikbare staat",
+                    "enable_discovery": "Ontdekking inschakelen"
+                }
+            },
+            "reconfigure_external": {
+                "description": "Herconfigureer uw externe scène instellingen en entiteiten.",
+                "data": {
+                    "number_tolerance": "Afrondingstolerantie",
+                    "restore_states_on_deactivate": "Status herstellen bij deactivering",
+                    "transition_time": "Transitie tijd",
+                    "debounce_time": "Debouncetijd",
+                    "ignore_unavailable": "Negeer entiteiten in niet-beschikbare staat",
+                    "scene_entities": "Scène entiteiten"
+                }
+            },
+            "reconfigure_external_learn": {
+                "description": "De scène is geactiveerd. Bevestig dat {entity_name} in de gewenste staat is.",
+                "data": {
+                    "external_scene_active": "Geactiveerd?"
+                }
             }
         },
         "error": {
@@ -47,6 +76,9 @@
             "unknown": "Onbekende fout",
             "no_entity_id": "Geen entiteit ID gevonden",
             "hub_not_found": "Hoofd integratie niet gevonden, configureer eerst Stateful Scenes"
+        },
+        "abort": {
+            "reconfigure_successful": "Configuratie succesvol bijgewerkt"
         }
     }
 }

--- a/custom_components/stateful_scenes/translations/sk.json
+++ b/custom_components/stateful_scenes/translations/sk.json
@@ -40,6 +40,35 @@
                 "data": {
                     "external_scene_active": "Aktivovaná?"
                 }
+            },
+            "reconfigure_hub": {
+                "description": "Prekonfigurujte nastavenia Stateful Scenes.",
+                "data": {
+                    "scene_path": "Cesta scény",
+                    "number_tolerance": "Tolerancia zaokrúhľovania",
+                    "restore_states_on_deactivate": "Obnovte stavy pri deaktivácii",
+                    "transition_time": "Čas prechodu",
+                    "debounce_time": "Čas odskoku",
+                    "ignore_unavailable": "Ignorovať entity v nedostupnom stave",
+                    "enable_discovery": "Povoliť objavovanie"
+                }
+            },
+            "reconfigure_external": {
+                "description": "Prekonfigurujte nastavenia externej scény a entity.",
+                "data": {
+                    "number_tolerance": "Tolerancia zaokrúhľovania",
+                    "restore_states_on_deactivate": "Obnovte stavy pri deaktivácii",
+                    "transition_time": "Čas prechodu",
+                    "debounce_time": "Čas odskoku",
+                    "ignore_unavailable": "Ignorovať entity v nedostupnom stave",
+                    "scene_entities": "Scénické entity"
+                }
+            },
+            "reconfigure_external_learn": {
+                "description": "Scéna bola aktivovaná. Potvrďte, že {entity_name} je v požadovanom stave.",
+                "data": {
+                    "external_scene_active": "Aktivovaná?"
+                }
             }
         },
         "error": {
@@ -48,6 +77,9 @@
             "unknown": "Vyskytla sa neznáma chyba",
             "no_entity_id": "ID entity nenájdená",
             "hub_not_found": "Hlavná položka sa nenašla, najskôr nakonfigurujte stavové scény"
+        },
+        "abort": {
+            "reconfigure_successful": "Konfigurácia bola úspešne aktualizovaná"
         }
     }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,19 +7,22 @@ import os
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stateful_scenes.const import (
     CONF_DEBOUNCE_TIME,
     CONF_ENABLE_DISCOVERY,
+    CONF_EXTERNAL_SCENE_ACTIVE,
     CONF_IGNORE_UNAVAILABLE,
     CONF_NUMBER_TOLERANCE,
     CONF_RESTORE_STATES_ON_DEACTIVATE,
+    CONF_SCENE_ENTITIES,
     CONF_SCENE_PATH,
     CONF_TRANSITION_TIME,
     DOMAIN,
 )
 
-from .const import SCENES_YAML_CONTENT
+from .const import MOCK_EXTERNAL_SCENE_DATA, MOCK_HUB_DATA, SCENES_YAML_CONTENT
 
 
 async def test_user_step_shows_menu(hass: HomeAssistant):
@@ -186,3 +189,175 @@ async def test_integration_discovery_step(hass: HomeAssistant):
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "configure_external_scene_entities"
+
+
+async def test_reconfigure_hub_shows_form(
+    hass: HomeAssistant, mock_config_entry_hub: MockConfigEntry, mock_scene_entities
+):
+    """Test reconfigure step for hub entry shows form with current values."""
+    await hass.config_entries.async_setup(mock_config_entry_hub.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry_hub.start_reconfigure_flow(hass)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_hub"
+
+
+async def test_reconfigure_hub_updates_entry(
+    hass: HomeAssistant, mock_config_entry_hub: MockConfigEntry, mock_scene_entities
+):
+    """Test reconfigure hub with valid input updates the config entry."""
+    await hass.config_entries.async_setup(mock_config_entry_hub.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry_hub.start_reconfigure_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_SCENE_PATH: "scenes.yaml",
+            CONF_NUMBER_TOLERANCE: 5,
+            CONF_RESTORE_STATES_ON_DEACTIVATE: True,
+            CONF_TRANSITION_TIME: 2.0,
+            CONF_DEBOUNCE_TIME: 0.5,
+            CONF_IGNORE_UNAVAILABLE: True,
+            CONF_ENABLE_DISCOVERY: True,
+        },
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Verify the entry was updated
+    assert mock_config_entry_hub.data[CONF_NUMBER_TOLERANCE] == 5
+    assert mock_config_entry_hub.data[CONF_RESTORE_STATES_ON_DEACTIVATE] is True
+    assert mock_config_entry_hub.data[CONF_TRANSITION_TIME] == 2.0
+    assert mock_config_entry_hub.data[CONF_DEBOUNCE_TIME] == 0.5
+    assert mock_config_entry_hub.data[CONF_IGNORE_UNAVAILABLE] is True
+    assert mock_config_entry_hub.data[CONF_ENABLE_DISCOVERY] is True
+
+
+async def test_reconfigure_hub_invalid_yaml(
+    hass: HomeAssistant, mock_config_entry_hub: MockConfigEntry, mock_scene_entities
+):
+    """Test reconfigure hub with invalid YAML shows error."""
+    await hass.config_entries.async_setup(mock_config_entry_hub.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry_hub.start_reconfigure_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_SCENE_PATH: "nonexistent.yaml",
+            CONF_NUMBER_TOLERANCE: 1,
+            CONF_RESTORE_STATES_ON_DEACTIVATE: False,
+            CONF_TRANSITION_TIME: 1.0,
+            CONF_DEBOUNCE_TIME: 0.0,
+            CONF_IGNORE_UNAVAILABLE: False,
+            CONF_ENABLE_DISCOVERY: False,
+        },
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "yaml_not_found"}
+
+
+async def test_reconfigure_external_shows_form(
+    hass: HomeAssistant,
+    mock_config_entry_external: MockConfigEntry,
+    mock_light_entities,
+):
+    """Test reconfigure step for external scene entry shows form."""
+    await hass.config_entries.async_setup(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry_external.start_reconfigure_flow(hass)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_external"
+
+
+async def test_reconfigure_external_updates_settings(
+    hass: HomeAssistant,
+    mock_config_entry_external: MockConfigEntry,
+    mock_light_entities,
+):
+    """Test reconfigure external with same entities updates settings only."""
+    await hass.config_entries.async_setup(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry_external.start_reconfigure_flow(hass)
+
+    # Submit with same entities (unchanged) - should update directly
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NUMBER_TOLERANCE: 3,
+            CONF_RESTORE_STATES_ON_DEACTIVATE: True,
+            CONF_TRANSITION_TIME: 1.5,
+            CONF_DEBOUNCE_TIME: 0.3,
+            CONF_IGNORE_UNAVAILABLE: True,
+            CONF_SCENE_ENTITIES: ["light.living_room", "light.bedroom"],
+        },
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Verify the entry was updated
+    assert mock_config_entry_external.data[CONF_NUMBER_TOLERANCE] == 3
+    assert mock_config_entry_external.data[CONF_RESTORE_STATES_ON_DEACTIVATE] is True
+    assert mock_config_entry_external.data[CONF_TRANSITION_TIME] == 1.5
+    assert mock_config_entry_external.data[CONF_DEBOUNCE_TIME] == 0.3
+    assert mock_config_entry_external.data[CONF_IGNORE_UNAVAILABLE] is True
+
+
+async def test_reconfigure_external_change_entities(
+    hass: HomeAssistant,
+    mock_config_entry_external: MockConfigEntry,
+    mock_light_entities,
+    service_calls,
+):
+    """Test reconfigure external with changed entities triggers re-learn."""
+    await hass.config_entries.async_setup(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    # Set up the scene entity for the turn_on call
+    hass.states.async_set(
+        "scene.external_test",
+        "scening",
+        {"friendly_name": "External Scene"},
+    )
+
+    result = await mock_config_entry_external.start_reconfigure_flow(hass)
+
+    # Submit with different entities - should go to learn step
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NUMBER_TOLERANCE: 1,
+            CONF_RESTORE_STATES_ON_DEACTIVATE: False,
+            CONF_TRANSITION_TIME: 1.0,
+            CONF_DEBOUNCE_TIME: 0.0,
+            CONF_IGNORE_UNAVAILABLE: False,
+            CONF_SCENE_ENTITIES: ["light.living_room"],  # removed bedroom
+        },
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_external_learn"
+
+    # Confirm the scene is active
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_EXTERNAL_SCENE_ACTIVE: True},
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Verify entities were re-learned (only living_room now)
+    assert "light.living_room" in mock_config_entry_external.data["entities"]
+    assert "light.bedroom" not in mock_config_entry_external.data["entities"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,7 +22,7 @@ from custom_components.stateful_scenes.const import (
     DOMAIN,
 )
 
-from .const import MOCK_EXTERNAL_SCENE_DATA, MOCK_HUB_DATA, SCENES_YAML_CONTENT
+from .const import SCENES_YAML_CONTENT
 
 
 async def test_user_step_shows_menu(hass: HomeAssistant):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,9 +6,11 @@ import os
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry, entity_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.stateful_scenes import (
+    async_remove_entry,
     load_scenes_file,
 )
 from custom_components.stateful_scenes.const import (
@@ -126,3 +128,130 @@ async def test_load_scenes_file_not_a_list(hass: HomeAssistant):
 
     with pytest.raises(StatefulScenesYamlInvalid):
         await load_scenes_file(hass, "notlist.yaml")
+
+
+async def test_async_remove_entry_cleans_up_entities_and_devices(
+    hass: HomeAssistant,
+    mock_config_entry_external: MockConfigEntry,
+    mock_light_entities,
+):
+    """Test removing a config entry cleans up its entities and devices."""
+    await hass.config_entries.async_setup(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    dr = device_registry.async_get(hass)
+
+    # Register a device and entity for this config entry
+    device = dr.async_get_or_create(
+        config_entry_id=mock_config_entry_external.entry_id,
+        identifiers={(DOMAIN, "test_device_1")},
+        name="Test Device",
+    )
+    er.async_get_or_create(
+        domain="switch",
+        platform=DOMAIN,
+        unique_id="ext_1001",
+        config_entry=mock_config_entry_external,
+        device_id=device.id,
+    )
+
+    # Verify entity and device exist
+    entities_before = [
+        e
+        for e in er.entities.values()
+        if e.config_entry_id == mock_config_entry_external.entry_id
+    ]
+    assert len(entities_before) >= 1
+
+    devices_before = [
+        d
+        for d in dr.devices.values()
+        if mock_config_entry_external.entry_id in d.config_entries
+    ]
+    assert len(devices_before) >= 1
+
+    # Unload then remove
+    await hass.config_entries.async_unload(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    await async_remove_entry(hass, mock_config_entry_external)
+
+    # Verify entities are removed
+    entities_after = [
+        e
+        for e in er.entities.values()
+        if e.config_entry_id == mock_config_entry_external.entry_id
+    ]
+    assert len(entities_after) == 0
+
+    # Verify devices are removed
+    devices_after = [
+        d
+        for d in dr.devices.values()
+        if mock_config_entry_external.entry_id in d.config_entries
+    ]
+    assert len(devices_after) == 0
+
+
+async def test_async_remove_entry_no_entities(
+    hass: HomeAssistant,
+    mock_config_entry_external: MockConfigEntry,
+    mock_light_entities,
+):
+    """Test removing an entry with no registered entities does not error."""
+    await hass.config_entries.async_setup(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_unload(mock_config_entry_external.entry_id)
+    await hass.async_block_till_done()
+
+    # Should not raise even with no entities/devices to clean up
+    await async_remove_entry(hass, mock_config_entry_external)
+
+
+async def test_async_remove_entry_hub(
+    hass: HomeAssistant,
+    mock_config_entry_hub: MockConfigEntry,
+    mock_scene_entities,
+):
+    """Test removing a hub config entry cleans up its devices."""
+    await hass.config_entries.async_setup(mock_config_entry_hub.entry_id)
+    await hass.async_block_till_done()
+
+    er = entity_registry.async_get(hass)
+    dr = device_registry.async_get(hass)
+
+    # Register a device for the hub entry
+    device = dr.async_get_or_create(
+        config_entry_id=mock_config_entry_hub.entry_id,
+        identifiers={(DOMAIN, "hub_device_1")},
+        name="Hub Device",
+    )
+    er.async_get_or_create(
+        domain="switch",
+        platform=DOMAIN,
+        unique_id="1001",
+        config_entry=mock_config_entry_hub,
+        device_id=device.id,
+    )
+
+    await hass.config_entries.async_unload(mock_config_entry_hub.entry_id)
+    await hass.async_block_till_done()
+
+    await async_remove_entry(hass, mock_config_entry_hub)
+
+    # Verify cleanup
+    entities_after = [
+        e
+        for e in er.entities.values()
+        if e.config_entry_id == mock_config_entry_hub.entry_id
+    ]
+    assert len(entities_after) == 0
+
+    devices_after = [
+        d
+        for d in dr.devices.values()
+        if mock_config_entry_hub.entry_id in d.config_entries
+    ]
+    assert len(devices_after) == 0


### PR DESCRIPTION
## Summary

Adds proper lifecycle management for config entries:

### Entry removal
- Implements `async_remove_entry` in `__init__.py` to clean up all associated entities and devices from the registries when a config entry is removed.

### Reconfigure flow
- Adds `async_step_reconfigure` to the config flow, supporting both hub and external scene entries.
- **Hub entries**: users can reconfigure scene path, tolerance, restore, transition time, debounce time, ignore unavailable, and discovery settings.
- **External scene entries**: users can reconfigure tolerance, restore, transition, debounce, ignore unavailable settings, and change which entities belong to the scene (triggers a re-learn step).
- Extracts shared schema builders (`_scene_settings_schema`, `_hub_schema`, `_external_schema`) and validation (`_async_validate_hub_input`) to reduce repetition.

### Translations
- Adds reconfigure step translations to `en.json`, `nl.json`, and `sk.json`.

### Tests
- Adds tests for `async_remove_entry` (with entities/devices, without, and for hub entries).
- Adds tests for the reconfigure flow (hub form, hub update, hub invalid YAML, external form, external settings update, external entity change with re-learn).