### PR TITLE
fix: Off Scene selector unavailable for scenes with special characters in name

### DIFF
--- a/custom_components/stateful_scenes/select.py
+++ b/custom_components/stateful_scenes/select.py
@@ -23,8 +23,10 @@ from homeassistant.core import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import slugify
 
 from .const import (
     DEFAULT_OFF_SCENE_ENTITY_ID,
@@ -202,9 +204,16 @@ class StatefulSceneOffSelect(SelectEntity, RestoreEntity):
             )
 
         # Set up callback for future state changes
-        restore_entity_id = (
-            f"switch.{self._scene.name.lower().replace(' ', '_')}_restore_on_deactivate"
+        restore_unique_id = f"{self._scene.id}_restore_on_deactivate"
+        ent_reg = async_get_entity_registry(self.hass)
+        restore_entity_id = ent_reg.async_get_entity_id(
+            "switch", DOMAIN, restore_unique_id
         )
+        if not restore_entity_id:
+            # Fall back to slugified name if entity not yet registered
+            restore_entity_id = (
+                f"switch.{slugify(f'{self._scene.name} Restore On Deactivate')}"
+            )
         async_track_state_change_event(
             self.hass, [restore_entity_id], self.async_update_restore_state
         )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.stateful_scenes.const import DEFAULT_OFF_SCENE_ENTITY_ID
+from custom_components.stateful_scenes.const import DEFAULT_OFF_SCENE_ENTITY_ID, DOMAIN
 
 
 async def test_select_entity_created_external(
@@ -74,3 +75,119 @@ async def test_select_change_off_scene(
         # Verify options are available
         options = state.attributes.get("options", [])
         assert DEFAULT_OFF_SCENE_ENTITY_ID in options
+
+
+async def test_select_available_with_special_chars_in_name(
+    hass: HomeAssistant,
+    mock_light_entities,
+):
+    """Test select entity tracks restore_on_deactivate switch for scenes with special chars.
+
+    Regression test for https://github.com/.../issues/251:
+    Scene names with parentheses, hyphens, etc. caused the Off Scene selector
+    to be permanently unavailable because the entity ID was manually constructed
+    from the name using only space-to-underscore replacement.
+    """
+    # Create an external scene with special characters in the name
+    special_scene_data = {
+        "name": "EFFECT_Christmas (Candy Canes)",
+        "entity_id": "scene.effect_christmas_candy_canes",
+        "id": "ext_special_1",
+        "area": None,
+        "learn": True,
+        "icon": None,
+        "number_tolerance": 1,
+        "entities": {
+            "light.living_room": {"state": "on", "brightness": 200},
+        },
+        "hub": False,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=special_scene_data,
+        title="EFFECT_Christmas (Candy Canes)",
+        unique_id="stateful_scene.effect_christmas_candy_canes",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Find the restore_on_deactivate switch entity
+    ent_reg = er.async_get(hass)
+    switch_entry = ent_reg.async_get_entity_id(
+        "switch", DOMAIN, "ext_special_1_learned_restore_on_deactivate"
+    )
+    assert switch_entry is not None, "Restore on deactivate switch should exist"
+
+    # Turn off the restore_on_deactivate switch to make the select available
+    hass.states.async_set(switch_entry, "off")
+    await hass.async_block_till_done()
+
+    # The select entity should become available
+    select_entity_id = ent_reg.async_get_entity_id(
+        "select", DOMAIN, "ext_special_1_learned_off_scene"
+    )
+    assert select_entity_id is not None, "Off scene select should exist"
+
+    state = hass.states.get(select_entity_id)
+    assert state is not None
+    assert state.state != "unavailable", (
+        "Off Scene select should be available after restore_on_deactivate is turned off, "
+        "even for scenes with special characters in the name"
+    )
+
+
+async def test_select_available_with_hyphenated_name(
+    hass: HomeAssistant,
+    mock_light_entities,
+):
+    """Test select entity works for scenes with hyphens in name."""
+    special_scene_data = {
+        "name": "Living Room - Evening",
+        "entity_id": "scene.living_room_evening",
+        "id": "ext_hyphen_1",
+        "area": None,
+        "learn": True,
+        "icon": None,
+        "number_tolerance": 1,
+        "entities": {
+            "light.living_room": {"state": "on", "brightness": 150},
+        },
+        "hub": False,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=special_scene_data,
+        title="Living Room - Evening",
+        unique_id="stateful_scene.living_room_evening",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Find the restore_on_deactivate switch entity via registry
+    ent_reg = er.async_get(hass)
+    switch_entry = ent_reg.async_get_entity_id(
+        "switch", DOMAIN, "ext_hyphen_1_learned_restore_on_deactivate"
+    )
+    assert switch_entry is not None, "Restore on deactivate switch should exist"
+
+    # Turn off restore_on_deactivate
+    hass.states.async_set(switch_entry, "off")
+    await hass.async_block_till_done()
+
+    # The select entity should become available
+    select_entity_id = ent_reg.async_get_entity_id(
+        "select", DOMAIN, "ext_hyphen_1_learned_off_scene"
+    )
+    assert select_entity_id is not None
+
+    state = hass.states.get(select_entity_id)
+    assert state is not None
+    assert state.state != "unavailable", (
+        "Off Scene select should be available for scenes with hyphens in the name"
+    )


### PR DESCRIPTION
## Summary

Fix the Off Scene selector being permanently unavailable for scenes with special characters (parentheses, hyphens, etc.) in their name.

## Problem

The `async_added_to_hass` method in `select.py` constructed the `restore_on_deactivate` switch entity ID using only `self._scene.name.lower().replace(' ', '_')`. This manual slugification didn't handle special characters like parentheses or hyphens, producing entity IDs that didn't match HA's actual entity IDs.

For example, a scene named `EFFECT_Christmas (Candy Canes)` would produce:
- **Expected:** `switch.effect_christmas_candy_canes_restore_on_deactivate`
- **Got:** `switch.effect_christmas_(candy_canes)_restore_on_deactivate`

Since the state change tracker was attached to the wrong entity ID, the select entity never received state updates and remained permanently unavailable.

## Fix

- Use entity registry lookup by `unique_id` (preferred when the switch is already registered)
- Fall back to `homeassistant.util.slugify` for proper entity ID construction (handles the case where the select entity is registered before the switch)

## Tests

Added two regression tests covering scenes with:
- Parentheses: `EFFECT_Christmas (Candy Canes)`
- Hyphens: `Living Room - Evening`

Fixes #251