### PR TITLE
fix: debounce time having no effect when transition time is zero

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -67,15 +67,16 @@ class SceneEvaluationTimer:
     async def async_start(self, callback) -> None:
         """Start a new timer if we have a duration."""
         await self.async_cancel_if_active()
-        if self.transition_time > 0 and self._hass is not None:
+        total_time = self.transition_time + self.debounce_time
+        if total_time > 0 and self._hass is not None:
             _LOGGER.debug(
                 "Starting scene evaluation timer for %s seconds",
-                self.transition_time + self.debounce_time,
+                total_time,
             )
 
             self._cancel_callback = async_call_later(
                 self._hass,
-                self.transition_time + self.debounce_time,
+                total_time,
                 callback,
             )
 

--- a/tests/test_stateful_scenes.py
+++ b/tests/test_stateful_scenes.py
@@ -404,11 +404,32 @@ class TestSceneEvaluationTimer:
         await timer.async_cancel_if_active()
 
     async def test_timer_does_not_start_with_zero_transition(self, hass: HomeAssistant):
-        """Test timer does not start when transition time is 0."""
+        """Test timer does not start when both transition and debounce time are 0."""
         timer = SceneEvaluationTimer(hass, 0.0, 0.0)
         callback = AsyncMock()
         await timer.async_start(callback)
         assert timer.is_active() is False
+
+    async def test_timer_starts_with_debounce_only(self, hass: HomeAssistant):
+        """Test timer starts when transition time is 0 but debounce time > 0.
+
+        Regression test for https://github.com/.../issues/233:
+        When transition time was 0 but debounce time was set, the timer would
+        not start, making debounce ineffective.
+        """
+        timer = SceneEvaluationTimer(hass, 0.0, 5.0)
+        callback = AsyncMock()
+        await timer.async_start(callback)
+        assert timer.is_active() is True
+        await timer.async_cancel_if_active()
+
+    async def test_timer_duration_debounce_only(self, hass: HomeAssistant):
+        """Test timer uses only debounce time when transition is 0."""
+        timer = SceneEvaluationTimer(hass, 0.0, 3.0)
+        callback = AsyncMock()
+        await timer.async_start(callback)
+        assert timer.is_active() is True
+        await timer.async_cancel_if_active()
 
     async def test_timer_cancel(self, hass: HomeAssistant):
         """Test cancelling an active timer."""


### PR DESCRIPTION
## Summary

Fix debounce time being ineffective when transition time is set to zero.

## Problem

The `SceneEvaluationTimer.async_start()` method only started the timer when `transition_time > 0`:

```python
if self.transition_time > 0 and self._hass is not None:
```

This meant that if a user set debounce time (e.g. 5 seconds) but left transition time at 0, the timer never started. The scene state was evaluated immediately on every entity state change, causing the switch to jump back to off and then on again as lights finished turning on.

## Fix

Changed the condition to check if the **total time** (transition + debounce) is greater than 0:

```python
total_time = self.transition_time + self.debounce_time
if total_time > 0 and self._hass is not None:
```

This allows debounce to work independently of transition time.

## Tests

- Updated `test_timer_does_not_start_with_zero_transition` to clarify it tests when **both** are 0
- Added `test_timer_starts_with_debounce_only` — verifies timer starts with transition=0, debounce=5
- Added `test_timer_duration_debounce_only` — verifies timer starts with transition=0, debounce=3

Fixes #233