### PR TITLE
Add button to recapture a scene without recreating it

### DIFF
--- a/custom_components/stateful_scenes/StatefulScenes.py
+++ b/custom_components/stateful_scenes/StatefulScenes.py
@@ -118,9 +118,10 @@ class SceneEvaluationTimer:
 class Scene:
     """State scene class."""
 
-    def __init__(self, hass: HomeAssistant, scene_conf: dict) -> None:
+    def __init__(self, hass: HomeAssistant, scene_conf: dict, config_entry: ConfigEntry | None = None) -> None:
         """Initialize."""
         self.hass = hass
+        self.config_entry = config_entry
         self.name: str = scene_conf[CONF_SCENE_NAME]
         self._entity_id: str = scene_conf[CONF_SCENE_ENTITY_ID]
         self._number_tolerance = scene_conf[CONF_SCENE_NUMBER_TOLERANCE]
@@ -635,6 +636,33 @@ class Scene:
             conf[entity].update(state.attributes)
         return conf
 
+    async def async_update_scene_definition(self):
+        """Update the scene definition from current entity states."""
+        for entity_id in self.entities:
+            state = self.hass.states.get(entity_id)
+            if state is None:
+                _LOGGER.warning("Scene %s: Entity %s not found in state machine", self.name, entity_id)
+                continue
+
+            entity_conf = {"state": state.state}
+
+            if state.domain in ATTRIBUTES_TO_CHECK:
+                for attribute in ATTRIBUTES_TO_CHECK.get(state.domain):
+                    if attribute in state.attributes:
+                        entity_conf[attribute] = state.attributes[attribute]
+
+            self.entities[entity_id] = entity_conf
+
+        _LOGGER.info("Updated scene definition for %s: %s", self.name, self.entities)
+
+        if self.config_entry:
+            new_data = self.config_entry.data.copy()
+            new_data[CONF_SCENE_ENTITIES] = self.entities
+            self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
+        await self.async_check_all_states()
+
 
 class Hub:
     """State scene class."""
@@ -777,3 +805,4 @@ class Hub:
         return next(
             (scene for scene in self.scenes if scene.entity_id == scene_id), None
         )
+

--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -24,6 +24,7 @@ from .StatefulScenes import Hub, Scene
 from .helpers import async_cleanup_orphaned_entities
 
 PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SWITCH,
@@ -59,7 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     else:
-        scene = Scene(hass, entry.data)
+        scene = Scene(hass, entry.data, config_entry=entry)
         hass.data[DOMAIN][entry.entry_id] = scene
 
         # Clean up orphaned entities for single scene setup

--- a/custom_components/stateful_scenes/button.py
+++ b/custom_components/stateful_scenes/button.py
@@ -1,0 +1,71 @@
+"""Platform for button integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import StatefulScenes
+from .const import DEVICE_INFO_MANUFACTURER, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> bool:
+    """Set up this integration using UI."""
+    assert hass is not None
+    data = hass.data[DOMAIN]
+    assert entry.entry_id in data
+    _LOGGER.debug(
+        "Setting up Stateful Scenes button with data: %s and config_entry %s",
+        data,
+        entry,
+    )
+
+    entities = []
+    if isinstance(data[entry.entry_id], StatefulScenes.Hub):
+        hub = data[entry.entry_id]
+        for scene in hub.scenes:
+            entities.append(RecaptureSceneButton(scene))
+
+    elif isinstance(data[entry.entry_id], StatefulScenes.Scene):
+        scene = data[entry.entry_id]
+        entities.append(RecaptureSceneButton(scene))
+
+    else:
+        _LOGGER.error("Invalid entity type for %s", entry.entry_id)
+        return False
+
+    async_add_entities(entities)
+
+    return True
+
+
+class RecaptureSceneButton(ButtonEntity):
+    """Button entity to recapture the scene state."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Recapture Scene"
+    _attr_icon = "mdi:eye-refresh"
+
+    def __init__(self, scene: StatefulScenes.Scene) -> None:
+        """Initialize."""
+        self._scene = scene
+        self._attr_unique_id = f"{scene.id}_recapture"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(self._scene.id,)},
+            name=self._scene.name,
+            manufacturer=DEVICE_INFO_MANUFACTURER,
+            suggested_area=self._scene.area_id,
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self._scene.async_update_scene_definition()


### PR DESCRIPTION
When using stateful scenes with external scene management, it's very laborious to have to recreate a scene, especially if it has a large number of objects in it.  This PR adds a simple button that lets you re-capture a scene.  I've had it in production on my own HA for a few months now and have become reliant upon it.

When managing scenes in Zigbee2mqtt, I often make a minor tweak which causes Stateful to get out of sync.  This button lets you recapture those attributes with a single press instead of a full scene recreation.

Most of the code is in the button and a single function added to the Scene object, although additional plumbing was added to pass necessary attributes.