### PR TITLE
fix: skip scenes with duplicate ids across Stateful Scenes entries

### DIFF
--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 
 import aiofiles
@@ -23,11 +24,31 @@ from .discovery import DiscoveryManager
 from .StatefulScenes import Hub, Scene
 from .helpers import async_cleanup_orphaned_entities
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SWITCH,
 ]
+
+
+def _get_registered_scene_ids(hass: HomeAssistant, exclude_entry_id: str) -> set[str]:
+    """Return scene ids already registered by other loaded config entries.
+
+    Used to avoid setting up scenes whose id is already claimed by another
+    Stateful Scenes config entry, which would otherwise create entities with
+    duplicate unique_ids (see hugobloem/stateful_scenes#209).
+    """
+    scene_ids: set[str] = set()
+    for other_entry_id, entry_data in hass.data.get(DOMAIN, {}).items():
+        if other_entry_id == exclude_entry_id:
+            continue
+        if isinstance(entry_data, Hub):
+            scene_ids.update(scene.id for scene in entry_data.scenes)
+        elif isinstance(entry_data, Scene):
+            scene_ids.add(entry_data.id)
+    return scene_ids
 
 
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
@@ -50,6 +71,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             scene_confs=scene_confs,
             number_tolerance=entry.data[CONF_NUMBER_TOLERANCE],
         )
+
+        # Skip scenes whose id is already claimed by another loaded config
+        # entry (e.g. a second Hub pointing at an overlapping scenes file)
+        # to avoid registering entities with duplicate unique_ids (#209).
+        registered_scene_ids = _get_registered_scene_ids(hass, entry.entry_id)
+        duplicate_scenes = [
+            scene for scene in hub.scenes if scene.id in registered_scene_ids
+        ]
+        for scene in duplicate_scenes:
+            _LOGGER.warning(
+                "Scene '%s' (id: %s) is already registered by another "
+                "Stateful Scenes config entry; skipping to avoid duplicate "
+                "entities",
+                scene.name,
+                scene.id,
+            )
+        if duplicate_scenes:
+            hub.scenes = [
+                scene for scene in hub.scenes if scene.id not in registered_scene_ids
+            ]
+
         hass.data[DOMAIN][entry.entry_id] = hub
 
         # Clean up orphaned entities for removed scenes

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -19,6 +21,8 @@ from custom_components.stateful_scenes.const import (
     StatefulScenesYamlNotFound,
 )
 from custom_components.stateful_scenes.StatefulScenes import Hub, Scene
+
+from .const import MOCK_HUB_DATA
 
 
 async def test_async_setup_entry_hub(
@@ -36,6 +40,50 @@ async def test_async_setup_entry_hub(
     assert len(hub.scenes) == 2
     assert hub.scenes[0].name == "Test Scene 1"
     assert hub.scenes[1].name == "Test Scene 2"
+
+
+async def test_async_setup_entry_hub_skips_already_registered_scene_ids(
+    hass: HomeAssistant, mock_scenes_yaml, mock_scene_entities, caplog
+):
+    """Two Hub entries loading overlapping scene ids must not duplicate entities.
+
+    Regression test for https://github.com/hugobloem/stateful_scenes/issues/209:
+    "Platform stateful_scenes does not generate unique IDs" log spam on startup,
+    caused by a second Stateful Scenes config entry registering number/select/
+    switch entities whose unique_id (derived from the underlying scene id) was
+    already claimed by another loaded entry.
+    """
+    entry1 = MockConfigEntry(domain=DOMAIN, data=MOCK_HUB_DATA, title="Hub 1")
+    entry1.add_to_hass(hass)
+    entry2 = MockConfigEntry(domain=DOMAIN, data=MOCK_HUB_DATA, title="Hub 2")
+    entry2.add_to_hass(hass)
+
+    # Setting up the first entry causes Home Assistant to also bootstrap any
+    # other not-yet-loaded config entries for this domain (mirroring what
+    # happens for real on a Home Assistant restart with two Hub entries).
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        assert await hass.config_entries.async_setup(entry1.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry2.state is ConfigEntryState.LOADED
+
+    duplicate_id_errors = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+        and "does not generate unique IDs" in record.message
+    ]
+    assert not duplicate_id_errors, (
+        "Setting up a second Hub entry with overlapping scene ids must not "
+        f"trigger duplicate unique ID errors, got: "
+        f"{[r.message for r in duplicate_id_errors]}"
+    )
+
+    # The second hub's scenes were already claimed by the first hub, so it
+    # should not attempt to re-register any of them.
+    hub2 = hass.data[DOMAIN][entry2.entry_id]
+    assert hub2.scenes == []
 
 
 async def test_async_setup_entry_external_scene(


### PR DESCRIPTION
## Summary

Fixes #209 - the `Platform stateful_scenes does not generate unique IDs. ID <id>_debounce_time already exists - ignoring number...` log spam that some users see on every Home Assistant startup.

## Root cause (verified, not assumed)

I initially assumed the auto-discovery feature was the culprit (re-registering scenes already defined under a Hub). I could **not** confirm that theory once I traced the real code paths:

- `DiscoveryManager.should_process_device` explicitly excludes any `scene.*` entity whose entity-registry `platform == "homeassistant"` - and I verified with a live test-harness run that scenes defined via the standard `scene:` YAML/UI editor (the ones with epoch-timestamp ids, exactly like the ids in the issue's log, e.g. `1743243029169`) are registered with `platform == "homeassistant"`. So discovery structurally cannot touch the scenes a Hub would already know about.
- Even when discovery *does* pick up a genuinely external scene (e.g. from another integration) and a user completes the "learn" flow for it, `Scene.id` for that entry is forced to `<id>_learned` (via `Scene.learn`), and `prepare_external_scene()`'s `id` value is actually derived from `get_id_from_entity_id()`, which - due to what looks like an unrelated pre-existing bug - resolves to the entity_id string, not the underlying numeric scene id. Both of these accidentally prevent that path from producing a literal duplicate `unique_id` with the current code, so it doesn't reproduce the reported symptom either.

What **does** reproduce the exact symptom (same ids, no `_learned` suffix, every scene in the file, every startup) is: **more than one Stateful Scenes config entry ending up with `Scene` objects that share the same `id`.** The most direct way this happens is two Hub-type config entries whose `scenes.yaml` (or overlapping scene files) both contain the same scene `id`s - e.g. a leftover/duplicate integration entry, or two Hub entries intentionally covering overlapping files. `number.py`, `select.py`, and `switch.py` all build `unique_id` as `f"{scene.id}_<suffix>"`, and nothing in `async_setup_entry` ever cross-checks a new Hub's scene ids against scene ids already claimed by another *loaded* config entry (`hass.data[DOMAIN]` only tracks per-entry state; the existing `valid_scene_ids` set built in `__init__.py` is only used for orphan-entity cleanup *within the same entry*, not for cross-entry duplicate detection). I confirmed this reproduces the identical log format from the issue with a real `pytest-homeassistant-custom-component` test that runs the actual `async_setup_entry` -> `async_forward_entry_setups` -> `number.py`/`select.py`/`switch.py` flow (see Testing below).

## Fix

`async_setup_entry` (in `custom_components/stateful_scenes/__init__.py`) now computes the set of scene ids already claimed by other *loaded* Stateful Scenes config entries (`_get_registered_scene_ids`) and filters them out of a newly-created Hub's `hub.scenes` before entities are created, logging one `_LOGGER.warning` per skipped scene instead of letting `number`/`select`/`switch` platforms attempt (and fail, noisily, at ERROR level) to register duplicate entities.

The diff is scoped to the Hub-setup path, which is the case I could reproduce and verify end-to-end.

## Testing (golden rule followed)

Added `tests/test_init.py::test_async_setup_entry_hub_skips_already_registered_scene_ids`, which:
1. Creates two Hub config entries both pointing at the same `scenes.yaml`.
2. Runs the real `hass.config_entries.async_setup(...)` flow (which, as I confirmed with the test harness, is also how Home Assistant bootstraps all not-yet-loaded entries of a domain together on a real restart).
3. Asserts no `"does not generate unique IDs"` ERROR-level log records are produced, and that the second Hub ends up with an empty `scenes` list (its scenes were already claimed).

Confirmed against unfixed code first, per the standard "write it red, then green" process:

```
$ uv run pytest tests/test_init.py::test_async_setup_entry_hub_skips_already_registered_scene_ids -q
...
ERROR homeassistant.components.number: Platform stateful_scenes does not generate unique IDs. ID 1001_transition_time already exists - ignoring number.test_scene_1_transition_time
... (16 total ERROR lines, exactly matching the issue's log shape)
E   AssertionError: Setting up a second Hub entry with overlapping scene ids must not trigger duplicate unique ID errors, got: [...]
1 failed in 0.19s
```

I additionally verified this with `git stash` (stash the fix in `__init__.py`, confirm the test still fails on the untouched base, then restore the fix and confirm it passes) to rule out any test-harness artifacts.

After the fix:
```
$ uv run pytest tests/test_init.py::test_async_setup_entry_hub_skips_already_registered_scene_ids -q
1 passed in 0.13s
```

Full suite and lint, before and after the fix:
```
$ uv run pytest -q
104 passed in 1.70s        # was 103 passed before adding the new test

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
20 files already formatted
```

## Risk to existing installations (duplicate entities already in the registry)

I looked into this carefully since it's the main risk with any "stop re-registering" change.

Home Assistant's entity registry enforces a hard uniqueness constraint on `(domain, platform, unique_id)` - it is **not possible** for two entities with the same unique_id to both exist in the registry at once. Every prior run, whichever config entry's platform setup reached `entity_platform._async_add_entity` **first** claimed the registry row; the other entry's entities were always rejected with the ERROR log and never created. I confirmed this behavior directly against the `entity_platform` source (`homeassistant/helpers/entity_platform.py`) and with the reproduction test.

Because of that:
- This fix does not remove or orphan any entity that currently exists for affected users. The "losing" entry's entities never made it into the registry in the first place - they were discarded every single startup, before and after this change.
- Entry setup order (and therefore which entry "wins") is unchanged by this fix - it's still whichever entry's `async_setup_entry` runs first, exactly as before. The fix just stops the loser from *attempting* the doomed registration, which removes the log spam without changing which entities exist.
- The one behavioral difference: the loser's `hub.scenes` list is now empty, so anything that iterates it (e.g. the orphaned-entity cleanup in `helpers.py`) sees an empty `valid_scene_ids` set for that entry. I checked `async_cleanup_orphaned_entities` - it only ever removes entities whose `config_entry_id` matches the *current* entry, and the losing entry has never owned any Stateful Scenes entities (per the point above), so there is nothing for it to incorrectly clean up.

What I could **not** validate: a real multi-Hub or Hub+external-scene setup against a live Home Assistant instance (only the test-harness reproduction), and I could not find comments/repro steps on the original issue to confirm the exact configuration the reporter has - my root-cause analysis is based on tracing the code paths and matching the exact log signature, not on a confirmed report from the user. I also did not touch the external ("learned") Scene config-entry path, since I could not reproduce a literal id collision through it with the current code (see Root cause above) - if it turns out to be relevant too, `_get_registered_scene_ids` already accounts for `Scene` entries and could be wired into that branch as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
